### PR TITLE
Add weigh factor for point level

### DIFF
--- a/canola.mp/data/com.metapolator/cps/master-canola.cps
+++ b/canola.mp/data/com.metapolator/cps/master-canola.cps
@@ -7,8 +7,12 @@ glyph, point > center, contour > p, component  {
     heightFactor: master:HeightF * glyph:HeightF;
 }
 
+point > left, point > right {
+   point: parent;
+}
+
 point > left, point > right, contour > p {
-    weightFactor: master:WeightF * glyph:WeightF;
+    weightFactor: master:WeightF * glyph:WeightF  * point:WeightF;
 }
 
 master {
@@ -24,5 +28,16 @@ glyph {
     SpacingS: 0;
     WidthF: 1;
     HeightF: 1;
+    WeightF: 1;
+}
+
+glyph {
+    SpacingS: 0;
+    WidthF: 1;
+    HeightF: 1;
+    WeightF: 1;
+}
+
+point {
     WeightF: 1;
 }


### PR DESCRIPTION
See: https://github.com/metapolator/metapolator/pull/713#issuecomment-188333844

When using non-local operators (like +) levels deeper (point level, in
the case of weigh) then visible in the UI can be effected.
